### PR TITLE
Fix botname to use id from slack and pretty name from slack

### DIFF
--- a/vectorslack/__main__.py
+++ b/vectorslack/__main__.py
@@ -2,16 +2,10 @@ import os
 from vectorslack import vector
 from slackclient import SlackClient
 import anki_vector
-import argparse
 
-parser = argparse.ArgumentParser(description='Connect Slack and Vector')
-parser.add_argument('--botname', type=str, dest='botname', default='VectorBot',
-                    help='Name of your bot')
-
-args = parser.parse_args()
 
 if __name__ == '__main__':
-    sc = SlackClient(os.environ['SLACK_TOKEN'])
+    slack_client = SlackClient(os.environ['SLACK_TOKEN'])
 
     with anki_vector.Robot(os.environ['VECTOR_SERIAL'], enable_camera_feed=True) as robot:
-        vector.start(args.botname, sc, robot)
+        vector.start(slack_client, robot)

--- a/vectorslack/tests/test_vector.py
+++ b/vectorslack/tests/test_vector.py
@@ -83,14 +83,14 @@ class TestVector(unittest.TestCase):
         mock_slack = Mock(spec=SlackClient)
         mock_slack_connected.side_effect = [True, False]
         mock_slack.rtm_read.return_value = events
-        mock_slack.api_call.return_value = {"user_id": "12345"}
+        mock_slack.api_call.return_value = {"user_id": "12345", "user": "vectorbot"}
 
         mock_command_parser = Mock(spec=CommandParser)
         mock_create_command.return_value = mock_command_parser
 
         mock_vector = Mock(spec=anki_vector.Robot)
 
-        vector.start("VectorBot", mock_slack, mock_vector)
+        vector.start(mock_slack, mock_vector)
 
         self.assertEqual(mock_handle_command.call_count, 2)
         mock_create_command.assert_called_with(mock_vector, mock_slack)

--- a/vectorslack/tests/test_vector.py
+++ b/vectorslack/tests/test_vector.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, patch, call
 
 import anki_vector
 from parameterized import parameterized
@@ -92,7 +92,14 @@ class TestVector(unittest.TestCase):
 
         vector.start(mock_slack, mock_vector)
 
+        handle_command_calls = [
+            call("say hi", "C2147483705", "vectorbot", mock_slack, mock_command_parser),
+            call("make heart eyes", "A45234", "vectorbot", mock_slack, mock_command_parser)
+
+        ]
         self.assertEqual(mock_handle_command.call_count, 2)
+        mock_handle_command.assert_has_calls(handle_command_calls)
+
         mock_create_command.assert_called_with(mock_vector, mock_slack)
         mock_slack.api_call.assert_called_with("auth.test")
 

--- a/vectorslack/tests/test_vector.py
+++ b/vectorslack/tests/test_vector.py
@@ -13,7 +13,7 @@ events = [
         "type": "message",
         "channel": "C2147483705",
         "user": "U2147483697",
-        "text": "@VectorBot say hi",
+        "text": "<@12345> say hi",
         "ts": "1355517523.000005"
     },
     {
@@ -41,7 +41,7 @@ events = [
         "type": "message",
         "channel": "A45234",
         "user": "U2147483697",
-        "text": "@VectorBot make heart eyes",
+        "text": "<@12345> make heart eyes",
         "ts": "1355517523.000005"
     },
 ]
@@ -50,9 +50,9 @@ events = [
 class TestVector(unittest.TestCase):
 
     @parameterized.expand([
-        ["matches", "@VectorBot go go", "VectorBot", "go go"],
-        ["does NOT matche", "@vector go go", None, None],
-        ["does match case insensitive", "@vectorbot go go", "vectorbot", "go go"],
+        ["matches", "<@VectorBot> go go", "VectorBot", "go go"],
+        ["does NOT matche", "<@vector> go go", None, None],
+        ["does match case insensitive", "<@vectorbot> go go", "vectorbot", "go go"],
     ])
     def test_parses_direct_mention_when_botname(self, name, message, expected_user, expected_message):
         user, message = vector.parse_direct_mention(message, "VectorBot")
@@ -71,7 +71,7 @@ class TestVector(unittest.TestCase):
             )
         ]
 
-        actual_events = vector.parse_bot_commands(events, "VectorBot")
+        actual_events = vector.parse_bot_commands(events, "12345")
 
         self.assertListEqual(actual_events, expected_events)
 
@@ -83,6 +83,7 @@ class TestVector(unittest.TestCase):
         mock_slack = Mock(spec=SlackClient)
         mock_slack_connected.side_effect = [True, False]
         mock_slack.rtm_read.return_value = events
+        mock_slack.api_call.return_value = {"user_id": "12345"}
 
         mock_command_parser = Mock(spec=CommandParser)
         mock_create_command.return_value = mock_command_parser
@@ -93,6 +94,7 @@ class TestVector(unittest.TestCase):
 
         self.assertEqual(mock_handle_command.call_count, 2)
         mock_create_command.assert_called_with(mock_vector, mock_slack)
+        mock_slack.api_call.assert_called_with("auth.test")
 
     def test_handle_command_say(self):
         mock_command_parser = Mock(spec=CommandParser)

--- a/vectorslack/vector.py
+++ b/vectorslack/vector.py
@@ -8,9 +8,10 @@ RTM_READ_DELAY = 1
 
 def start(botname, slack_client, robot):
     command_parser = create_command_parser(robot, slack_client)
+    starterbot_id = slack_client.api_call("auth.test")["user_id"]
     if slack_client.rtm_connect():
         while slack_connected(slack_client) is True:
-            parse_events(botname, slack_client, command_parser)
+            parse_events(starterbot_id, slack_client, command_parser)
             time.sleep(RTM_READ_DELAY)
     else:
         print("Connection Failed")
@@ -49,7 +50,7 @@ def parse_direct_mention(message_text, botname):
 
 
 def get_mention_regex(botname):
-    return "^@(%s)(.*)" % botname
+    return "^<@(%s)>(.*)" % botname
 
 
 def handle_command(message, channel, botname, slack_client, command_parser):

--- a/vectorslack/vector.py
+++ b/vectorslack/vector.py
@@ -6,12 +6,14 @@ from vectorslack.command_parser import CommandParser, SUPPORTED_COMMANDS
 RTM_READ_DELAY = 1
 
 
-def start(botname, slack_client, robot):
+def start(slack_client, robot):
     command_parser = create_command_parser(robot, slack_client)
-    starterbot_id = slack_client.api_call("auth.test")["user_id"]
+    bot_details = slack_client.api_call("auth.test")
+    bot_id = bot_details["user_id"]
+    bot_name = bot_details["user"]
     if slack_client.rtm_connect():
         while slack_connected(slack_client) is True:
-            parse_events(starterbot_id, slack_client, command_parser)
+            parse_events(bot_id, bot_name, slack_client, command_parser)
             time.sleep(RTM_READ_DELAY)
     else:
         print("Connection Failed")
@@ -25,10 +27,10 @@ def slack_connected(slack_client):
     return slack_client.server.connected
 
 
-def parse_events(botname, slack_client, command_parser):
-    events = parse_bot_commands(slack_client.rtm_read(), botname)
+def parse_events(bot_id, bot_name, slack_client, command_parser):
+    events = parse_bot_commands(slack_client.rtm_read(), bot_id)
     for event in events:
-        handle_command(event[0], event[1], botname, slack_client, command_parser)
+        handle_command(event[0], event[1], bot_name, slack_client, command_parser)
 
 
 def parse_bot_commands(slack_events, botname):
@@ -53,7 +55,7 @@ def get_mention_regex(botname):
     return "^<@(%s)>(.*)" % botname
 
 
-def handle_command(message, channel, botname, slack_client, command_parser):
+def handle_command(message, channel, bot_name, slack_client, command_parser):
     default_response = "I'm not sure what you mean."
 
     response = None
@@ -65,7 +67,7 @@ def handle_command(message, channel, botname, slack_client, command_parser):
         message_contents = lower_case_message.replace(command, '', 1).strip()
 
         getattr(command_parser, attribute_name)(command=message_contents, channel=channel)
-        response = "%s is a go go" % botname
+        response = "%s is a go go" % bot_name
     except StopIteration as e:
         print("Failed to parse command " + message)
 


### PR DESCRIPTION
When you @ a real person, slack gives you the id, not the text name so retrieve that from the api to identify calls to the right slackbot.
