### PR TITLE
Pin protobuff to version 3.20.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ slackclient==v2.8.2
 anki_vector==v0.6.0
 parameterized==v0.6.1
 Pillow>=3.3
+protobuf==3.20.1


### PR DESCRIPTION
Google released an update[1] which includes breaking changes, the anki
sdk used any version of googleapis-common-protos which means we get
version 4.x but we only work with version 3.20.x and we get:

TypeError: Descriptors cannot not be created directly.
If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.
If you cannot immediately regenerate your protos, some other possible workarounds are:
 1. Downgrade the protobuf package to 3.20.x or lower.
 2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).

[1] https://developers.google.com/protocol-buffers/docs/news/2022-05-06#python-updates